### PR TITLE
[fixed] file pointer have to be closed before return

### DIFF
--- a/toys/net/netstat.c
+++ b/toys/net/netstat.c
@@ -115,7 +115,11 @@ static void show_ip(char *fname)
      return;
   }
 
-  if(!fgets(toybuf, sizeof(toybuf), fp)) return; //skip header.
+  if(!fgets(toybuf, sizeof(toybuf), fp)) 
+  {
+	fclose(fp);	 
+	return; //skip header.
+  }
 
   while (fgets(toybuf, sizeof(toybuf), fp)) {
     char lip[256], rip[256];


### PR DESCRIPTION
예외처리 구문에 fclose(fp) 추가합니다.
